### PR TITLE
Elysian #54   increase default size limit for request body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elysian",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elysian",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elysian",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "A self-hosted tool to backup your regularly used bookmarks from the bookmarks toolbar of your browser to your home lab.",
   "main": "server.js",
   "repository": {

--- a/src/routes/delete_bookmark.js
+++ b/src/routes/delete_bookmark.js
@@ -5,6 +5,6 @@ const deleteBookmarkController = require('../controllers/deleteBookmarkControlle
 //Route used when bookmarkis deleted from the browser and sent to server for deletion
 //http://<IP>:6161/api/delete_bookmark
 //REST Verb: DELETE
-router.delete('/', express.json(), deleteBookmarkController.handleDeleteBookmark);
+router.delete('/', express.json({limit: '10mb'}), deleteBookmarkController.handleDeleteBookmark);
 
 module.exports = router;

--- a/src/routes/export_to_elysian.js
+++ b/src/routes/export_to_elysian.js
@@ -5,6 +5,6 @@ const exportToElysianController = require('../controllers/exportToElysianControl
 //Route used when bookmarks are sent from browser to the server
 //http://<IP>:6161/api/export_to_elysian
 //REST Verb: POST
-router.post('/', express.json(), exportToElysianController.handleExportToElysian);
+router.post('/', express.json({limit: '10mb'}), exportToElysianController.handleExportToElysian);
 
 module.exports = router;

--- a/src/routes/import_from_elysian.js
+++ b/src/routes/import_from_elysian.js
@@ -5,6 +5,6 @@ const importFromElysianController = require('../controllers/importFromElysianCon
 //Route used when bookmarks are sent from server to the browser
 //http://<IP>:6161/api/import_from_elysian
 //REST Verb: GET
-router.get('/', express.json(), importFromElysianController.handleImportFromElysian);
+router.get('/', express.json({limit: '10mb'}), importFromElysianController.handleImportFromElysian);
 
 module.exports = router;


### PR DESCRIPTION
Closes #54
Import and export endpoints are tested with request payload consisting of 3000 bookmarks and they are showing the expected behaviour now. 